### PR TITLE
Account deletion backend

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -25,8 +25,8 @@ class User(db.Model):
     twitter_name = db.Column(db.String(255))
     twitter_id = db.Column(db.String(255))
 
-    facebook_auth = db.relationship("FacebookAuth", uselist=False, back_populates="user")
-    twitter_auth = db.relationship("TwitterAuth", uselist=False, back_populates="user")
+    facebook_auth = db.relationship("FacebookAuth", uselist=False, back_populates="user", cascade="delete, delete-orphan")
+    twitter_auth = db.relationship("TwitterAuth", uselist=False, back_populates="user", cascade="delete, delete-orphan")
 
     twitter_authorized = db.Column(db.Boolean, nullable=False, default=False)
     facebook_authorized = db.Column(db.Boolean, nullable=False, default=False)
@@ -37,7 +37,7 @@ class User(db.Model):
     political_affiliation = db.Column(db.Enum(PoliticsEnum), default=PoliticsEnum.center)
 
     posts = db.relationship("Post",
-                    secondary=post_associations_table, lazy='dynamic')
+                            secondary=post_associations_table, lazy='dynamic')
 
     settings = db.relationship("Settings", uselist=False, back_populates="user")
 

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -72,30 +72,31 @@ def delete_account():
             db.session.query(Post).filter(Post.id == pid).delete()
 
         # delete user info from other tables
-        (db.session.query(FacebookAuth)
-            .filter(FacebookAuth.user_id == user_id)
-            .delete())
-        (db.session.query(TwitterAuth)
-            .filter(TwitterAuth.user_id == user_id)
-            .delete())
+        # (db.session.query(FacebookAuth)
+        #     .filter(FacebookAuth.user_id == user_id)
+        #     .delete())
+        # (db.session.query(TwitterAuth)
+        #     .filter(TwitterAuth.user_id == user_id)
+        #     .delete())
         (db.session.query(SettingsUpdate)
             .filter(SettingsUpdate.user_id == user_id)
             .delete())
         db.session.query(Settings).filter(Settings.user_id == user_id).delete()
 
         # delete user from users table
-        db.session.query(User).filter(User.id == user_id).delete()
-
+        acct = db.session.query(User).filter(User.id == user_id).first()
+        db.session.delete(acct)
         db.session.commit()
 
         status = True
     except Exception as e:
+        print e
         status = False
         logger.exception(e)
 
     db.session.close()
 
-    logout_user()
+    # logout_user()
     return jsonify({'result': status})
 
 

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -4,7 +4,7 @@ from flask_login import login_required, login_user, logout_user, current_user
 from sqlalchemy.exc import IntegrityError
 
 from server.core import db, bcrypt
-from server.models import User
+from server.models import User, Post, SettingsUpdate, Settings, TwitterAuth, FacebookAuth, post_associations_table
 from server.blueprints import api
 
 logger = logging.getLogger(__name__)
@@ -55,6 +55,39 @@ def login():
     response = jsonify({'result': status, 'user':user_result})
     return response
 
+@api.route ('/delete_acct', methods=['GET'])
+@login_required
+def delete_account():
+    user_id = current_user.id
+    try:
+        #delete posts with post_associations matching user_id
+        post_assocs = db.session.query(post_associations_table).filter(post_associations_table.c.user_id==user_id)
+        post_ids = [post_id for (user_id,post_id) in post_assocs.all()]   
+        post_assocs.delete(synchronize_session=False)
+
+        for pid in post_ids:
+            db.session.query(Post).filter(Post.id==pid).delete()
+
+        #delete user info from other tables
+        db.session.query(FacebookAuth).filter(FacebookAuth.user_id==user_id).delete()
+        db.session.query(TwitterAuth).filter(TwitterAuth.user_id==user_id).delete()
+        db.session.query(SettingsUpdate).filter(SettingsUpdate.user_id==user_id).delete()
+        db.session.query(Settings).filter(Settings.user_id==user_id).delete()
+
+        #delete user from users table
+        db.session.query(User).filter(User.id==user_id).delete()
+
+        db.session.commit()
+
+        statusText = 'Account successfully deleted'
+    except Exception as e:
+        statusText = 'Account unsuccessfully deleted: ' + str(e)
+        logger.exception(e)
+
+    db.session.close()
+
+    logout_user()
+    return jsonify({'result': statusText})
 
 @api.route('/logout', methods=['GET'])
 @login_required
@@ -67,3 +100,4 @@ def logout():
 @login_required
 def confirm_auth():
     return jsonify({'result': current_user.is_authenticated(), 'user': current_user.get_names()})
+

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -34,8 +34,8 @@ def register():
         except IntegrityError:
             status_text = 'A user with that e-mail already exist!'
         except Exception as e:
-            status_text = ('Sorry, but something went wrong.. \
-                         Please reload the page and try again.')
+            status_text = """Sorry, but something went wrong..Please reload
+                              the page and try again"""
             logger.exception(e)
         db.session.close()
     return jsonify({'statusText': status_text}), code

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -4,7 +4,8 @@ from flask_login import login_required, login_user, logout_user, current_user
 from sqlalchemy.exc import IntegrityError
 
 from server.core import db, bcrypt
-from server.models import User, Post, SettingsUpdate, Settings, TwitterAuth, FacebookAuth, post_associations_table
+from server.models import (User, Post, SettingsUpdate, Settings,
+                           TwitterAuth, FacebookAuth, post_associations_table)
 from server.blueprints import api
 
 logger = logging.getLogger(__name__)
@@ -28,18 +29,19 @@ def register():
             db.session.add(user)
             db.session.commit()
             status_text = 'success'
-            code=200
+            code = 200
             login_user(user, remember=True)
         except IntegrityError:
             status_text = 'A user with that e-mail already exist!'
         except Exception as e:
-            status_text = 'Sorry, but something went wrong.  Please reload the page and try again.'
+            status_text = ('Sorry, but something went wrong.. \
+                         Please reload the page and try again.')
             logger.exception(e)
         db.session.close()
     return jsonify({'statusText': status_text}), code
 
 
-@api.route ('/login', methods=['POST'])
+@api.route('/login', methods=['POST'])
 def login():
     json_data = request.json
     user_result = False
@@ -52,30 +54,38 @@ def login():
     else:
         status = False
 
-    response = jsonify({'result': status, 'user':user_result})
+    response = jsonify({'result': status, 'user': user_result})
     return response
 
-@api.route ('/delete_acct', methods=['GET'])
+
+@api.route('/delete_acct', methods=['GET'])
 @login_required
 def delete_account():
     user_id = current_user.id
     try:
-        #delete posts with post_associations matching user_id
-        post_assocs = db.session.query(post_associations_table).filter(post_associations_table.c.user_id==user_id)
-        post_ids = [post_id for (user_id,post_id) in post_assocs.all()]   
+        # delete posts with post_associations matching user_id
+        post_assocs = (db.session.query(post_associations_table)
+                       .filter(post_associations_table.c.user_id == user_id))
+        post_ids = [post_id for (user_id, post_id) in post_assocs.all()]
         post_assocs.delete(synchronize_session=False)
 
         for pid in post_ids:
-            db.session.query(Post).filter(Post.id==pid).delete()
+            db.session.query(Post).filter(Post.id == pid).delete()
 
-        #delete user info from other tables
-        db.session.query(FacebookAuth).filter(FacebookAuth.user_id==user_id).delete()
-        db.session.query(TwitterAuth).filter(TwitterAuth.user_id==user_id).delete()
-        db.session.query(SettingsUpdate).filter(SettingsUpdate.user_id==user_id).delete()
-        db.session.query(Settings).filter(Settings.user_id==user_id).delete()
+        # delete user info from other tables
+        (db.session.query(FacebookAuth)
+            .filter(FacebookAuth.user_id == user_id)
+            .delete())
+        (db.session.query(TwitterAuth)
+            .filter(TwitterAuth.user_id == user_id)
+            .delete())
+        (db.session.query(SettingsUpdate)
+            .filter(SettingsUpdate.user_id == user_id)
+            .delete())
+        db.session.query(Settings).filter(Settings.user_id == user_id).delete()
 
-        #delete user from users table
-        db.session.query(User).filter(User.id==user_id).delete()
+        # delete user from users table
+        db.session.query(User).filter(User.id == user_id).delete()
 
         db.session.commit()
 
@@ -89,6 +99,7 @@ def delete_account():
     logout_user()
     return jsonify({'result': statusText})
 
+
 @api.route('/logout', methods=['GET'])
 @login_required
 def logout():
@@ -96,8 +107,8 @@ def logout():
     return jsonify('logout')
 
 
-@api.route ('/confirm_auth', methods=['GET'])
+@api.route('/confirm_auth', methods=['GET'])
 @login_required
 def confirm_auth():
-    return jsonify({'result': current_user.is_authenticated(), 'user': current_user.get_names()})
-
+    return jsonify({'result': current_user.is_authenticated(),
+                    'user': current_user.get_names()})

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -4,8 +4,7 @@ from flask_login import login_required, login_user, logout_user, current_user
 from sqlalchemy.exc import IntegrityError
 
 from server.core import db, bcrypt
-from server.models import (User, Post, SettingsUpdate, Settings,
-                           TwitterAuth, FacebookAuth, post_associations_table)
+from server.models import *
 from server.blueprints import api
 
 logger = logging.getLogger(__name__)
@@ -89,15 +88,15 @@ def delete_account():
 
         db.session.commit()
 
-        statusText = 'Account successfully deleted'
+        status = True
     except Exception as e:
-        statusText = 'Account unsuccessfully deleted: ' + str(e)
+        status = False
         logger.exception(e)
 
     db.session.close()
 
     logout_user()
-    return jsonify({'result': statusText})
+    return jsonify({'result': status})
 
 
 @api.route('/logout', methods=['GET'])


### PR DESCRIPTION
Working on half of issue #40, this introduces the `delete_acct` api endpoint from deleting the current user's account.

Deletes posts, the other settings and auth info, and finally the user. 

One thing to note is that for the post associations table, because it's not a model, I had to add the `synchronize_session` parameter and set it False. I found this technique on [this](https://stackoverflow.com/questions/37759161/deleted-rows-from-reflected-table-with-sqlalchemy) stackoverflow post. 