### PR TITLE
First attempt at re-architecting content fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,25 @@ After that you should be able to see Gobo at localhost:5000
 
 ### Recurring Tasks
 
-You need to set up two recurring tasks. The first adds tasks to the queue:
+You need to set up three recurring tasks. The first adds tasks to the queue to fetch FB and Twitter posts for users that
+have been using the system recently.  Run this frequently (every 15 minutes or so?):
 ```shell
-$ python -m server.scripts.add_tasks_to_queue
+$ python -m server.scripts.add_incremental_tasks_to_queue
 ```
 
-The second removes old posts (Gobo only tracks the last 500 posts for each user):
+The second updates the posts from news organizations (used for the "perspectives" filter). Run this every 3 hours or so:
+```shell
+$ python -m server.scripts.get_perspective_posts
+```
+
+The third removes old posts (Gobo only tracks the last 500 posts for each user). Run this once a night:
 ```shell
 $ python -m server.scripts.clean_old_posts
 ```
 
-To refresh a specific user:
+### Manual Tasks
+
+To queue up a task that refreshes a specific user:
 ```shell
 $ python -m server.scripts.add_user_tasks_to_queue [user_id]
 ```

--- a/client/app/components/Landing/Landing.js
+++ b/client/app/components/Landing/Landing.js
@@ -53,7 +53,7 @@ const Landing = (props) => {
 					feed. Want to read news you aren't otherwise seeing? Use our "Echo Chamber" filter to see what
 					we call "wider" news. Want a better balance of men and women in your feed? Use our "gender"
 					filter to rebalance it. Want to take a lunch break and just see popular funny videos you friends
-					are sharing? Use our "virality" filter to pick only the most shared content. With Gogo you're in
+					are sharing? Use our "virality" filter to pick only the most shared content. With Gobo you're in
 					charge of the algorithmic filters that control what you see on social media. We've built a bunch
 					of filters like these already, are building more, and have made it possible for other developers
 					to add filters too. Sign up, try it out, and see if it changes how you think about how social

--- a/migrations/versions/e1c458791003_add_last_login_and_post_update_columns.py
+++ b/migrations/versions/e1c458791003_add_last_login_and_post_update_columns.py
@@ -1,0 +1,26 @@
+"""add last login and post update columns
+
+Revision ID: e1c458791003
+Revises: f72e54a6c741
+Create Date: 2018-01-29 23:09:47.273168
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e1c458791003'
+down_revision = 'f72e54a6c741'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('last_login', sa.DateTime, nullable=True))
+    op.add_column('users', sa.Column('last_post_fetch', sa.DateTime, nullable=True))
+
+
+def downgrade():
+    drop_column('users', 'last_login')
+    drop_column('users', 'last_post_fetch')

--- a/migrations/versions/e1c458791003_add_last_login_and_post_update_columns.py
+++ b/migrations/versions/e1c458791003_add_last_login_and_post_update_columns.py
@@ -22,5 +22,5 @@ def upgrade():
 
 
 def downgrade():
-    drop_column('users', 'last_login')
-    drop_column('users', 'last_post_fetch')
+    op.drop_column('users', 'last_login')
+    op.drop_column('users', 'last_post_fetch')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,12 @@
+import os
+import logging.config
+import json
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+
+# set up logging
+with open(os.path.join(base_dir, 'config', 'logging.json'), 'r') as f:
+    logging_config = json.load(f)
+    logging.config.dictConfig(logging_config)
+
+logging.debug("Running from " + base_dir)

--- a/server/config/configTemplate.py
+++ b/server/config/configTemplate.py
@@ -46,6 +46,10 @@ class BaseConfig(object):
     # use to score whether somethign is news or not for our filter. We have an instance running for developers to use.
     NEWS_LABELLER_URL = 'http://my_predict_news_server'
 
+    #Settings to control how users are prioritized in the queue
+    NUMBER_OF_USERS_TO_UPDATE = 30
+    HOURS_TO_WAIT = 6
+
 
 class DevConfig(BaseConfig):
     DEBUG = True

--- a/server/config/logging.json
+++ b/server/config/logging.json
@@ -10,6 +10,12 @@
   },
 
   "handlers": {
+    "console": {
+      "level": "DEBUG",
+      "class": "logging.StreamHandler",
+      "formatter": "generic",
+      "stream": "ext://sys.stdout"
+    },
     "file": {
       "level": "DEBUG",
       "class": "logging.handlers.RotatingFileHandler",
@@ -23,9 +29,9 @@
 
   "loggers": {
     "": {
-      "handlers": ["file"],
+      "handlers": ["file", "console"],
       "level": "DEBUG",
-      "propagate": true
+      "propagate": false
     }
   }
 

--- a/server/factory.py
+++ b/server/factory.py
@@ -10,13 +10,12 @@ from .config.config import config_map
 from .blueprints import all_blueprints
 
 
-
-
 def create_app(config_type):
 
     config = config_map[config_type]
 
-    app = Flask(__name__,  template_folder=config.TEMPLATE_FOLDER, static_url_path=config.STATIC_URL_PATH, static_folder=config.STATIC_FOLDER)
+    app = Flask(__name__,  template_folder=config.TEMPLATE_FOLDER, static_url_path=config.STATIC_URL_PATH,
+                static_folder=config.STATIC_FOLDER)
 
     app.config.from_object(config)
 
@@ -28,7 +27,6 @@ def create_app(config_type):
     login_manager.init_app(app)
     migrate.init_app(app, db)
 
-
     # register_blueprints
     for bp in all_blueprints:
         import_module(bp.import_name)
@@ -36,7 +34,6 @@ def create_app(config_type):
     #
     # app.wsgi_app = HTTPMethodOverrideMiddleware(app.wsgi_app)
     return app
-
 
 
 def create_celery_app(app=None):

--- a/server/models.py
+++ b/server/models.py
@@ -77,11 +77,11 @@ class User(db.Model):
         d['avatar'] = self.twitter_data['profile_image_url_https'] if self.twitter_data else self.facebook_picture_url
         return d
 
-    def set_last_login(self):
+    def update_last_login(self):
         self.last_login = datetime.datetime.now()
         db.session.commit()
 
-    def set_last_post_fetch(self):
+    def update_last_post_fetch(self):
         self.last_post_fetch = datetime.datetime.now()
         db.session.commit()
 

--- a/server/models.py
+++ b/server/models.py
@@ -3,10 +3,10 @@ from server.core import db, bcrypt
 from server.enums import GenderEnum, PoliticsEnum, EchoRangeEnum
 
 post_associations_table = db.Table('posts_associations', db.metadata,
-    db.Column('user_id', db.Integer, db.ForeignKey('users.id')),
-    db.Column('post_id', db.Integer, db.ForeignKey('posts.id')),
-    db.PrimaryKeyConstraint('user_id', 'post_id'),
-)
+                                   db.Column('user_id', db.Integer, db.ForeignKey('users.id')),
+                                   db.Column('post_id', db.Integer, db.ForeignKey('posts.id')),
+                                   db.PrimaryKeyConstraint('user_id', 'post_id'))
+
 
 class User(db.Model):
 
@@ -28,8 +28,10 @@ class User(db.Model):
     twitter_name = db.Column(db.String(255))
     twitter_id = db.Column(db.String(255))
 
-    facebook_auth = db.relationship("FacebookAuth", uselist=False, back_populates="user", cascade="delete, delete-orphan")
-    twitter_auth = db.relationship("TwitterAuth", uselist=False, back_populates="user", cascade="delete, delete-orphan")
+    facebook_auth = db.relationship("FacebookAuth", uselist=False, back_populates="user",
+                                    cascade="delete, delete-orphan")
+    twitter_auth = db.relationship("TwitterAuth", uselist=False, back_populates="user",
+                                   cascade="delete, delete-orphan")
 
     twitter_authorized = db.Column(db.Boolean, nullable=False, default=False)
     facebook_authorized = db.Column(db.Boolean, nullable=False, default=False)
@@ -39,8 +41,7 @@ class User(db.Model):
 
     political_affiliation = db.Column(db.Enum(PoliticsEnum), default=PoliticsEnum.center)
 
-    posts = db.relationship("Post",
-                            secondary=post_associations_table, lazy='dynamic')
+    posts = db.relationship("Post", secondary=post_associations_table, lazy='dynamic')
 
     settings = db.relationship("Settings", uselist=False, back_populates="user")
 
@@ -97,9 +98,9 @@ class User(db.Model):
         self.facebook_authorized = True
         db.session.commit()
 
-    def set_twitter_data(self, id, name, data):
+    def set_twitter_data(self, twitter_id, name, data):
         self.twitter_name = name
-        self.twitter_id = id
+        self.twitter_id = twitter_id
         self.twitter_data = data
         self.twitter_authorized = True
         db.session.commit()
@@ -114,6 +115,7 @@ class User(db.Model):
 
     def __repr__(self):
         return '<User {0}>'.format(self.email)
+
 
 class FacebookAuth(db.Model):
     __tablename__ = "facebook_auths"
@@ -132,6 +134,7 @@ class FacebookAuth(db.Model):
         self.token_type = facebook_auth_data['token_type']
         self.expires_in = self.generated_on + datetime.timedelta(seconds=int(facebook_auth_data['expires_in']))
 
+
 class TwitterAuth(db.Model):
     __tablename__ = "twitter_auths"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
@@ -147,6 +150,7 @@ class TwitterAuth(db.Model):
         self.oauth_token = oauth_token
         self.oauth_token_secret = oauth_token_secret
 
+
 class Settings(db.Model):
     __tablename__ = "user_settings"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
@@ -155,7 +159,8 @@ class Settings(db.Model):
     rudeness_min = db.Column(db.Float, db.CheckConstraint('rudeness_min>=0'), default=0)
     rudeness_max = db.Column(db.Float, db.CheckConstraint('rudeness_max<=1'), default=1)
     gender_filter_on = db.Column(db.Boolean, default=False)
-    gender_female_per = db.Column(db.Integer, db.CheckConstraint('gender_female_per>=0 AND gender_female_per<=100'), default=50)
+    gender_female_per = db.Column(db.Integer, db.CheckConstraint('gender_female_per>=0 AND gender_female_per<=100'),
+                                  default=50)
     include_corporate = db.Column(db.Boolean, default=True)
     virality_min = db.Column(db.Float, db.CheckConstraint('virality_min>=0'), default=0)
     virality_max = db.Column(db.Float, db.CheckConstraint('virality_max<=1'), default=1)
@@ -168,10 +173,9 @@ class Settings(db.Model):
     seriousness_ck = db.CheckConstraint('seriousness_max>seriousness_min')
 
     def as_dict(self):
-        d = {c.name: getattr(self, c.name) for c in self.__table__.columns if c.name!='echo_range'}
+        d = {c.name: getattr(self, c.name) for c in self.__table__.columns if c.name != 'echo_range'}
         d['echo_range'] = self.echo_range.value
         return d
-
 
     def update(self, settings_dict):
         self.rudeness_min = settings_dict['rudeness_min']
@@ -185,6 +189,7 @@ class Settings(db.Model):
         self.seriousness_max = settings_dict['seriousness_max']
         self.echo_range = EchoRangeEnum(settings_dict['echo_range'])
 
+
 class SettingsUpdate(db.Model):
     __tablename__ = "settings_updates"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
@@ -196,6 +201,7 @@ class SettingsUpdate(db.Model):
         self.user_id = user_id
         self.update_time = datetime.datetime.now()
         self.new_settings = new_settings
+
 
 class Post(db.Model):
     __tablename__ = "posts"
@@ -218,22 +224,22 @@ class Post(db.Model):
 
     db.UniqueConstraint('source_id', 'source', name='post_id')
 
-
     def __init__(self, original_id, source, content, is_news):
         self.original_id = original_id
         self.source = source
         self.content = content
         self.is_news = is_news
         self.retrieved_at = datetime.datetime.now()
-        if source=='twitter':
+        if source == 'twitter':
             self.created_at = datetime.datetime.strptime(content['created_at'], '%a %b %d %H:%M:%S +0000 %Y')
-            self.has_link = len(content['entities']['urls']) > 0 # 'possibly_sensitive' in content
+            self.has_link = len(content['entities']['urls']) > 0  # 'possibly_sensitive' in content
         else:
             self.created_at = datetime.datetime.strptime(content['created_time'], '%Y-%m-%dT%H:%M:%S+0000')
-            self.has_link = content['type']=='link'
+            self.has_link = content['type'] == 'link'
 
     def as_dict(self):
-        d = {c.name: getattr(self, c.name) for c in self.__table__.columns if c.name not in ['gender', 'political_quintile']}
+        d = {c.name: getattr(self, c.name) for c in self.__table__.columns
+             if c.name not in ['gender', 'political_quintile']}
         d['gender'] = str(self.gender)
         d['political_quintile'] = self.political_quintile.value if self.political_quintile else None
         return d
@@ -241,9 +247,9 @@ class Post(db.Model):
     def get_text(self):
         # TODO: logic fore getting text - should we get text from link shared, etc?
         text = ""
-        if self.source=="twitter":
+        if self.source == "twitter":
             text = self.content['full_text'] if 'full_text' in self.content else self.content['text']
-        if self.source=="facebook":
+        if self.source == "facebook":
             text = self.content['message'] if 'message' in self.content else ""
         return text
 
@@ -280,14 +286,13 @@ class Post(db.Model):
         return self.news_score is not None
 
     def has_already_been_analyzed(self):
-        return self.has_virality() and self.has_news_score() and self.has_gender_corporate() and self.has_toxicity_rate()
+        return self.has_virality() and self.has_news_score() and self.has_gender_corporate()\
+               and self.has_toxicity_rate()
 
     def get_author_name(self):
-        if self.source=='facebook':
+        if self.source == 'facebook':
             return self.content['from']['name']
         else:
             if 'retweeted_status' in self.content:
                 return self.content['retweeted_status']['user']['name']
             return self.content['user']['name']
-
-

--- a/server/models.py
+++ b/server/models.py
@@ -77,6 +77,10 @@ class User(db.Model):
         d['avatar'] = self.twitter_data['profile_image_url_https'] if self.twitter_data else self.facebook_picture_url
         return d
 
+    def set_last_login(self):
+        self.last_login = datetime.datetime.now()
+        db.session.commit()
+
     def set_last_post_fetch(self):
         self.last_post_fetch = datetime.datetime.now()
         db.session.commit()

--- a/server/models.py
+++ b/server/models.py
@@ -18,6 +18,9 @@ class User(db.Model):
     registered_on = db.Column(db.DateTime, nullable=False)
     completed_registration = db.Column(db.Boolean, default=False)
 
+    last_login = db.Column(db.DateTime, nullable=True)
+    last_post_fetch = db.Column(db.DateTime, nullable=True)
+
     facebook_name = db.Column(db.String(255))
     facebook_picture_url = db.Column(db.String(255))
     facebook_id = db.Column(db.String(255))
@@ -45,6 +48,7 @@ class User(db.Model):
         self.email = email
         self.password = bcrypt.generate_password_hash(password)
         self.registered_on = datetime.datetime.now()
+        self.last_login = datetime.datetime.now()
         settings = Settings()
         self.settings = settings
 
@@ -60,12 +64,22 @@ class User(db.Model):
     def get_id(self):
         return self.id
 
+    def get_last_login(self):
+        return self.last_login
+
+    def get_last_post_fetch(self):
+        return self.last_post_fetch
+
     def get_names(self):
         d = {c.name: getattr(self, c.name) for c in self.__table__.columns if c.name not in [
             'password', 'id', 'political_affiliation', 'posts', 'settings', 'facebook_data']}
         d['political_affiliation'] = self.political_affiliation.value
         d['avatar'] = self.twitter_data['profile_image_url_https'] if self.twitter_data else self.facebook_picture_url
         return d
+
+    def set_last_post_fetch(self):
+        self.last_post_fetch = datetime.datetime.now()
+        db.session.commit()
 
     def set_facebook_data(self, data):
         self.facebook_name = data['name'] if 'name' in data else ''

--- a/server/scripts/__init__.py
+++ b/server/scripts/__init__.py
@@ -1,15 +1,3 @@
-import os
-import logging.config
-import json
 from ..factory import create_celery_app
 
 celery = create_celery_app()
-
-# base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-#
-# # set up logging
-# with open(os.path.join(base_dir, 'config', 'logging.json'), 'r') as f:
-#     logging_config = json.load(f)
-#     logging.config.dictConfig(logging_config)
-#
-# logging.info("Running from "+base_dir)

--- a/server/scripts/add_incremental_tasks_to_queue.py
+++ b/server/scripts/add_incremental_tasks_to_queue.py
@@ -2,6 +2,6 @@ import tasks as tasks
 
 if __name__ == '__main__':
     # get post data for some users:
-    tasks.get_posts_data_for_some_users.delay()
+    tasks.get_posts_data_for_some_users()
     #should news posts be updated??
-    tasks.get_news_posts.delay()
+    #tasks.get_news_posts

--- a/server/scripts/add_incremental_tasks_to_queue.py
+++ b/server/scripts/add_incremental_tasks_to_queue.py
@@ -1,0 +1,7 @@
+import tasks as tasks
+
+if __name__ == '__main__':
+    # get post data for some users:
+    tasks.get_posts_data_for_some_users.delay()
+    #should news posts be updated??
+    tasks.get_news_posts.delay()

--- a/server/scripts/analyze_modules.py
+++ b/server/scripts/analyze_modules.py
@@ -8,7 +8,6 @@
 from ..models import Post
 from googleapiclient import discovery 
 from flask import current_app
-import tasks
 from logging import getLogger
 from server.enums import GenderEnum 
 from .gender_classifier.NameClassifier_light import NameClassifier

--- a/server/scripts/clean_old_posts.py
+++ b/server/scripts/clean_old_posts.py
@@ -4,7 +4,11 @@
 import os
 import psycopg2
 import urlparse
-from ..config.config import config_map
+import logging
+
+from server.config.config import config_map
+
+logger = logging.getLogger(__name__)
 
 
 env = os.getenv('FLASK_ENV', 'dev')
@@ -28,13 +32,24 @@ cur = conn.cursor()
 
 q1 = "DELETE FROM posts_associations WHERE post_id in(SELECT id FROM posts WHERE  DATE_PART('day', NOW() - retrieved_at) > {});".format(NUM_DAYS)
 q2 = "DELETE FROM posts WHERE DATE_PART('day', NOW() - retrieved_at) > {};".format(NUM_DAYS)
+q3 = "DELETE FROM posts WHERE id IN (" \
+     "SELECT posts.id " \
+     "FROM posts LEFT JOIN posts_associations ON posts.id = posts_associations.post_id " \
+     "GROUP BY posts.id " \
+     "HAVING COUNT(posts_associations.user_id) = 0" \
+     ")"
 
 try:
-    cur.execute(q1)
-    cur.execute(q2)
+    result = cur.execute(q1)
+    logging.info("Deleted {} old posts_associations".format(result))
+    result = cur.execute(q2)
+    logging.info("Deleted {} old posts".format(result))
+    result = cur.execute(q3)
+    logging.info("Deleted {} orphaned posts".format(result))
 
     conn.commit()
-except:
+except Exception as e:
+    logger.exception(e)
     print "There was an error executing posts clean up"
 
 cur.close()

--- a/server/scripts/delete_user.py
+++ b/server/scripts/delete_user.py
@@ -1,10 +1,13 @@
 import sys
 import os
-from ..views.auth import delete_user_by_id
+import logging
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from ..config.config import config_map
 
+from server.views.auth import delete_user_by_id
+from server.config.config import config_map
+
+logger = logging.getLogger(__name__)
 
 env = os.getenv('FLASK_ENV', 'dev')
 config_type = env.lower()
@@ -14,4 +17,11 @@ engine = create_engine(config.SQLALCHEMY_DATABASE_URI)
 Session = sessionmaker(bind=engine)
 session = Session()
 
-print delete_user_by_id(sys.argv[1], session)
+if len(sys.argv) is not 2:
+    logger.error("You have to provide a user_id to delete!")
+
+user_id = int(sys.argv[1])
+
+logger.info("Delete user ".format(user_id))
+deletion_worked = delete_user_by_id(user_id, session)
+logger.info("Success: {}".format(deletion_worked))

--- a/server/scripts/get_perspective_posts.py
+++ b/server/scripts/get_perspective_posts.py
@@ -1,0 +1,4 @@
+import tasks as tasks
+
+if __name__ == '__main__':
+    tasks.get_news_posts()

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -83,6 +83,9 @@ def get_tweets_per_user(self, user_id):
         commits_succeeded += result['success']
         commits_failed += not result['success']
 
+    if posts_added:
+        user.set_last_post_fetch()
+
     logger.info('Done getting tweets for user {}, total {} tweets added to db. {} commits succeeded. '
                '{} commits failed.'.format(user_id, posts_added, commits_succeeded, commits_failed))
 
@@ -101,6 +104,10 @@ def get_facebook_posts_per_user(self, user_id):
         posts_added += result['added_new']
         commits_succeeded += result['success']
         commits_failed += not result['success']
+
+    if posts_added:
+        user.set_last_post_fetch()
+
     logger.info('Done getting facebook posts for user {}, total {} posts added to db. {} commits succeeded. '
                '{} commits failed.'.format(user_id, posts_added, commits_succeeded, commits_failed))
 
@@ -245,5 +252,3 @@ def get_news_posts(self):
                         for p in result["data"]:
                             post = dict(p, **{'post_user': object})
                             _add_news_post(post, 'facebook', quintile)
-
-

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -113,7 +113,7 @@ def get_tweets_per_user(self, user_id):
         commits_failed += not result['success']
 
     if posts_added:
-        user.set_last_post_fetch()
+        user.update_last_post_fetch()
 
     logger.info('Done getting tweets for user {}, total {} tweets added to db. {} commits succeeded. '
                '{} commits failed.'.format(user_id, posts_added, commits_succeeded, commits_failed))
@@ -135,7 +135,7 @@ def get_facebook_posts_per_user(self, user_id):
         commits_failed += not result['success']
 
     if posts_added:
-        user.set_last_post_fetch()
+        user.update_last_post_fetch()
 
     logger.info('Done getting facebook posts for user {}, total {} posts added to db. {} commits succeeded. '
                '{} commits failed.'.format(user_id, posts_added, commits_succeeded, commits_failed))

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -71,7 +71,7 @@ def get_posts_data_for_some_users(self):
     time_window = (datetime.now() - User.last_post_fetch) > timedelta(hours=config_map[env].HOURS_TO_WAIT)
 
     #from most recent logins, grab users that haven't had their posts updated in the provided window
-    oldest_post_fetches = recent_logins.filter(User.last_post_fetch is not None).filter(time_window).limit(config_map['prod'].NUMBER_OF_USERS_TO_UPDATE)
+    oldest_post_fetches = recent_logins.filter(User.last_post_fetch is not None).filter(time_window).limit(config_map[env].NUMBER_OF_USERS_TO_UPDATE)
     prioritized_users.extend(oldest_post_fetches.all())
 
     #to fill up the queue, find users who perhaps haven't logged in recently but also haven't had their posts updated in awhile

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -58,7 +58,7 @@ def get_posts_data_for_all_users(self):
         if user.facebook_authorized:
             get_facebook_posts_per_user.delay(user.id)
 
-@celery.task(serializer='json', bind=True)
+
 def get_posts_data_for_some_users(self):
     #filter for people who haven't updated in awhile but logged in recently
     prioritized_users = []
@@ -240,7 +240,6 @@ def analyze_post(self, post_id):
     #analyze_news_score(post_id)
 
 
-@celery.task(serializer='json', bind=True)
 def get_news_posts(self):
     #facebook requests payload
     N = 2

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -52,7 +52,32 @@ name_classifier = NameClassifier()
 
 @celery.task(serializer='json', bind=True)
 def get_posts_data_for_all_users(self):
-    for user in User.query.all():
+    for user in User.query.filter_by():
+        if user.twitter_authorized:
+            get_tweets_per_user.delay(user.id)
+        if user.facebook_authorized:
+            get_facebook_posts_per_user.delay(user.id)
+
+@celery.task(serializer='json', bind=True)
+def get_posts_data_for_some_users(self):
+    #filter for people who haven't updated in awhile but logged in recently
+    prioritized_users = []
+
+    #look for most recent logins (not null)
+    recent_logins = User.query.filter(User.last_login is not None).order_by(User.last_login.desc())
+
+    time_window = (datetime.now() - User.last_post_fetch) > timedelta(hours=config_map['prod'].HOURS_TO_WAIT)
+
+    #from most recent logins, grab users that haven't had their posts updated in the provided window
+    oldest_post_fetches = recent_logins.filter(User.last_post_fetch is not None).filter(time_window).limit(config_map['prod'].NUMBER_OF_USERS_TO_UPDATE)
+    prioritized_users.extend(oldest_post_fetches.all())
+
+    #to fill up the queue, find users who perhaps haven't logged in recently but also haven't had their posts updated in awhile
+    if oldest_post_fetches.all() < config_map['prod'].NUMBER_OF_USERS_TO_UPDATE:
+        oldest_post_fetches_with_no_login = User.query.filter(User.last_login is None).filter(time_window).order_by(User.last_post_fetch).limit(config_map['prod'].NUMBER_OF_USERS_TO_UPDATE - len(oldest_post_fetches))
+        prioritized_users.extend(oldest_post_fetches_with_no_login.all())
+
+    for user in prioritized_users:
         if user.twitter_authorized:
             get_tweets_per_user.delay(user.id)
         if user.facebook_authorized:

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -71,12 +71,14 @@ def get_posts_data_for_some_users(self):
     time_window = (datetime.now() - User.last_post_fetch) > timedelta(hours=config_map[env].HOURS_TO_WAIT)
 
     #from most recent logins, grab users that haven't had their posts updated in the provided window
-    oldest_post_fetches = recent_logins.filter(User.last_post_fetch is not None).filter(time_window).limit(config_map[env].NUMBER_OF_USERS_TO_UPDATE)
+    oldest_post_fetches = recent_logins.filter(User.last_post_fetch is not None).filter(time_window).limit(
+        config_map[env].NUMBER_OF_USERS_TO_UPDATE)
     prioritized_users.extend(oldest_post_fetches.all())
 
     #to fill up the queue, find users who perhaps haven't logged in recently but also haven't had their posts updated in awhile
-    if oldest_post_fetches.all() < config_map['prod'].NUMBER_OF_USERS_TO_UPDATE:
-        oldest_post_fetches_with_no_login = User.query.filter(User.last_login is None).filter(time_window).order_by(User.last_post_fetch).limit(config_map['prod'].NUMBER_OF_USERS_TO_UPDATE - len(oldest_post_fetches))
+    if oldest_post_fetches.all() < config_map[env].NUMBER_OF_USERS_TO_UPDATE:
+        oldest_post_fetches_with_no_login = User.query.filter(User.last_login is None).filter(time_window).order_by(
+            User.last_post_fetch).limit(config_map[env].NUMBER_OF_USERS_TO_UPDATE - len(oldest_post_fetches))
         prioritized_users.extend(oldest_post_fetches_with_no_login.all())
 
     for user in prioritized_users:

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -63,10 +63,12 @@ def get_posts_data_for_some_users(self):
     #filter for people who haven't updated in awhile but logged in recently
     prioritized_users = []
 
+    env = os.getenv('FLASK_ENV', 'dev')
+
     #look for most recent logins (not null)
     recent_logins = User.query.filter(User.last_login is not None).order_by(User.last_login.desc())
 
-    time_window = (datetime.now() - User.last_post_fetch) > timedelta(hours=config_map['prod'].HOURS_TO_WAIT)
+    time_window = (datetime.now() - User.last_post_fetch) > timedelta(hours=config_map[env].HOURS_TO_WAIT)
 
     #from most recent logins, grab users that haven't had their posts updated in the provided window
     oldest_post_fetches = recent_logins.filter(User.last_post_fetch is not None).filter(time_window).limit(config_map['prod'].NUMBER_OF_USERS_TO_UPDATE)

--- a/server/scripts/tasks.py
+++ b/server/scripts/tasks.py
@@ -52,7 +52,7 @@ name_classifier = NameClassifier()
 
 @celery.task(serializer='json', bind=True)
 def get_posts_data_for_all_users(self):
-    for user in User.query.filter_by():
+    for user in User.query.all():
         if user.twitter_authorized:
             get_tweets_per_user.delay(user.id)
         if user.facebook_authorized:

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -111,7 +111,6 @@ def delete_user_by_id(user_id, db_session):
 
         status = True
     except Exception as e:
-        print e
         status = False
         logger.exception(e)
 

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -49,6 +49,7 @@ def login():
             user.password, json_data['password']):
         login_user(user, remember=True)
         user_result = user.get_names()
+        current_user.set_last_login()
         status = True
     else:
         status = False

--- a/server/views/auth.py
+++ b/server/views/auth.py
@@ -49,7 +49,7 @@ def login():
             user.password, json_data['password']):
         login_user(user, remember=True)
         user_result = user.get_names()
-        current_user.set_last_login()
+        current_user.update_last_login()
         status = True
     else:
         status = False


### PR DESCRIPTION
This references #31 and #55. It adds two columns to the db for tracking users' most recent logins and post fetches (via alembic migration and model change). It then adds a new `add_incremental_tasks_to_queue` task to celery that prioritizes users that should have new posts fetch.

The logic is as follows:

- sort for most recent logins that are not null
- filter those for data fetches that were more than 6 hours ago
- add those to the list of prioritized users
- if list is not filled with predetermined # of users to queue, sort for people who have a null recent login date, and filter those for data fetches that were more than 6 hours ago


Closes #55 