### PR TITLE
Fix Facebook Twitter button PropTypes

### DIFF
--- a/client/app/components/FacebookTwitterButtons/FacebookTwitterButtons.js
+++ b/client/app/components/FacebookTwitterButtons/FacebookTwitterButtons.js
@@ -8,12 +8,12 @@ import { postFacebookResponseToServer } from '../../utils/apiRequests';
 
 
 const propTypes = {
-  dispatch: PropTypes.func.isRequired,
-  twitter_data: PropTypes.object.isRequired,
-  facebookConnected: PropTypes.func,
-  twitterConnected: PropTypes.func,
-  auth: PropTypes.object,
-  // onFinish: PropTypes.func.isRequired,
+	dispatch: PropTypes.func.isRequired,
+	twitter_data: PropTypes.object.isRequired,
+	facebookConnected: PropTypes.bool,
+	twitterConnected: PropTypes.bool,
+	auth: PropTypes.object,
+	// onFinish: PropTypes.func.isRequired,
 };
 
 const MAX_POLLS = 120;


### PR DESCRIPTION
I noticed that there was an error being thrown in the console. The `PropTypes` for `FacebookTwitterButtons` wasn't set properly. 

They are provided booleans:
https://github.com/mitmedialab/gobo/blob/00515a99de3495d7470ac28e9ecd382d802b0c12/client/app/components/Profile/Profile.js#L97