### PR TITLE
Use ORM for prioritized queue task

### DIFF
--- a/client/app/constants/index.js
+++ b/client/app/constants/index.js
@@ -18,6 +18,6 @@ export const DELETE_USER_REQUEST = 'DELETE_USER_REQUEST';
 export const DELETE_USER_SUCCESS = 'DELETE_USER_SUCCESS';
 export const DELETE_USER_FAILURE = 'DELETE_USER_FAILURE';
 
-export const VERSION = 'v1.5.0';
+export const VERSION = 'v1.5.1';
 
 export const API_URL = '';  // process.env.NODE_ENV === 'production' ? '': 'http://localhost:5000/'


### PR DESCRIPTION
This fixes a problem where the generated SQL wasn't exactly valid. The text input column names didn't match the ORM generated ones meaning the last two parts of the prioritization weren't run.