### PR TITLE
Mastodon action list icons will link to post

### DIFF
--- a/client/app/components/Post/ActionListMastodon.js
+++ b/client/app/components/Post/ActionListMastodon.js
@@ -9,16 +9,19 @@ const ActionListMastodon = (props) => {
   const likes = {
     name: 'likes',
     count: content.favourites_count || 0,
+    link: content.uri,
     icon: 'glyphicon glyphicon-star-empty',
   };
   const comments = {
     name: 'comments',
     count: content.replies_count,
+    link: content.uri,
     icon: 'icon-twitter-comment',
   };
   const shares = {
     name: 'shares',
     count: content.reblogs_count || 0,
+    link: content.uri,
     icon: 'icon-twitter_retweet',
   };
   return (


### PR DESCRIPTION
Fixes #171 